### PR TITLE
Add promisify.method

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,13 @@ readFile('input')
   .then((content) => writeFile('output', content))
   .catch((err) => console.error('err', err));
 
+// If you just care about one method, a less verbose option you can use is promisify.method:
+const readFileAsync = promisify.method(fs, 'readFile');
+
+readFileAsync('input')
+	.then((content) => writeFile('output', content))
+	.catch((err) => console.error('err', err));
+
 // If you know all the methods of the object are asynchronous, use promisify.all:
 const api = {
   respondWithDelay

--- a/spec/promisifySpec.js
+++ b/spec/promisifySpec.js
@@ -63,6 +63,22 @@ describe('promisify', function() {
     expect(await promisify(ex)()).toBe('surprise!');
   });
 
+  describe('method', function() {
+    it('should promisify the given method', async function() {
+      const api = {
+        beep(done) {
+          process.nextTick(() => done(null, 8));
+        }
+      };
+
+      const origBeep = api.beep;
+      const beepPromiseAPI = promisify.method(api, 'beep');
+
+      expect(api.beep).toBe(origBeep);
+      expect(await beepPromiseAPI()).toBe(8);
+    });
+  });
+
   describe('methods', function() {
     it('should promisify the given methods', async function() {
       const api = {

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ module.exports = {
   unpatchPromise,
   deferred,
   promisify,
+  promisifyMethod: promisify.method,
   promisifyMethods: promisify.methods,
   promisifyAll: promisify.all,
 };

--- a/src/promisify.js
+++ b/src/promisify.js
@@ -78,6 +78,18 @@ function promisify(orig, options) {
 }
 
 /**
+ * Promisify the given name on the given object, and create a copy of the object.
+ *
+ * @param {*} obj A value that can have properties.
+ * @param {String} methodName The method to promisify.
+ * @param {Boolean|String[]} options.variadic See the documentation for promisify.
+ * @return {Object} The promisified object.
+ */
+function promisifyMethod(obj, methodName, options) {
+  return promisifyMethods(obj, [methodName], options)[methodName];
+}
+
+/**
  * Promisify the given names on the given object, and create a copy of the object.
  *
  * @param {*} obj A value that can have properties.
@@ -127,6 +139,7 @@ function promisifyAll(obj, options) {
 promisify.custom = kCustomPromisifiedSymbol;
 
 promisify.all = promisifyAll;
+promisify.method = promisifyMethod;
 promisify.methods = promisifyMethods;
 promisify.promisifyAll = promisifyAll;
 promisify.promisifyMethods = promisifyMethods;


### PR DESCRIPTION
Add shortcut for when you just want to `promisify` one function.

```
// If you just care about one method, a less verbose option you can use is promisify.method:
const readFileAsync = promisify.method(fs, 'readFile');
 
readFileAsync('input')
	.then((content) => writeFile('output', content))
	.catch((err) => console.error('err', err));
 ```