### PR TITLE
Use explicit exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ function unpatchPromise() {
   method.unpatchPromise();
 }
 
-module.exports = {
+module.exports = Object.assign({
   patchPromise,
   unpatchPromise,
   deferred,
@@ -25,8 +25,4 @@ module.exports = {
   promisifyMethod: promisify.method,
   promisifyMethods: promisify.methods,
   promisifyAll: promisify.all,
-};
-
-for (let method of require('./statics')) {
-  module.exports[method.name] = method;
-}
+}, require('./statics'));

--- a/src/static.js
+++ b/src/static.js
@@ -4,11 +4,11 @@ const staticProperties = require('./statics');
 
 function patchPromise() {
   const props = {};
-  for (let fn of staticProperties) {
-    if (Promise[fn.name] && Promise[fn.name] !== fn) {
-      throw new Error(`Promise already defines ${fn.name}.`);
+  for (const [fnName, fn] of Object.entries(staticProperties)) {
+    if (Promise[fnName] && Promise[fnName] !== fn) {
+      throw new Error(`Promise already defines ${fnName}.`);
     }
-    props[fn.name] = {
+    props[fnName] = {
       configurable: true,
       enumerable: false,
       writable: true,
@@ -19,9 +19,9 @@ function patchPromise() {
 }
 
 function unpatchPromise() {
-  for (let fn of staticProperties) {
-    if (Promise[fn.name] === fn) {
-      delete Promise[fn.name];
+  for (const [fnName, fn] of Object.entries(staticProperties)) {
+    if (Promise[fnName] === fn) {
+      delete Promise[fnName];
     }
   }
 }
@@ -32,6 +32,4 @@ module.exports = {
   statics: {}
 };
 
-for (let fn of staticProperties) {
-  module.exports.statics[fn.name] = fn;
-}
+Object.assign(module.exports.statics, staticProperties);

--- a/src/statics/index.js
+++ b/src/statics/index.js
@@ -1,11 +1,11 @@
 'use strict';
 
-module.exports = [
-  require('./asCallback'),
-  require('./delay'),
-  require('./immediate'),
-  require('./nextTick'),
-  require('./waitOn'),
-  require('./withTimeout'),
-  require('./wrapAsync'),
-];
+module.exports = {
+  asCallback: require('./asCallback'),
+  delay: require('./delay'),
+  immediate: require('./immediate'),
+  nextTick: require('./nextTick'),
+  waitOn: require('./waitOn'),
+  withTimeout: require('./withTimeout'),
+  wrapAsync: require('./wrapAsync'),
+};


### PR DESCRIPTION
Fixes #16, also currently impacting minified builds client-side, and causing a bug where the waitOn function isn't available (and it somehow doesn't fail in the correct way).