### PR TITLE
Use proper explicit exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const static_ = require('./static');
 const deferred = require('./deferred');
 const defer = require('./defer');
 const promisify = require('./promisify');
+const statics = require('./statics');
 
 function patchPromise() {
   static_.patchPromise();
@@ -16,13 +17,20 @@ function unpatchPromise() {
   method.unpatchPromise();
 }
 
-module.exports = Object.assign({
-  patchPromise,
-  unpatchPromise,
-  deferred,
-  defer,
-  promisify,
-  promisifyMethod: promisify.method,
-  promisifyMethods: promisify.methods,
-  promisifyAll: promisify.all,
-}, require('./statics'));
+// For some reason, rollup-plugin-commonjs wants this form instead of one embedded in the
+// module.exports object definition.
+exports.patchPromise = patchPromise;
+exports.unpatchPromise = unpatchPromise;
+exports.deferred = deferred;
+exports.defer = defer;
+exports.promisify = promisify;
+exports.promisifyMethod = promisify.method,
+exports.promisifyMethods = promisify.methods,
+exports.promisifyAll = promisify.all,
+exports.asCallback = statics.asCallback;
+exports.delay = statics.delay;
+exports.immediate = statics.immediate;
+exports.nextTick = statics.nextTick;
+exports.waitOn = statics.waitOn;
+exports.withTimeout = statics.withTimeout;
+exports.wrapAsync = statics.wrapAsync;


### PR DESCRIPTION
The prior attempt - #17 - did not use explicit exports at the top-level module, where they really matter, and rollup-plugin-commonjs is very picky about the exact form used for exports.

Fixes #16 forreal.