### PR TITLE
fix: expose callback exceptions as uncaught

### DIFF
--- a/src/statics/asCallback.js
+++ b/src/statics/asCallback.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const tick = typeof process === 'object' ? process.nextTick : (fn) => setTimeout(() => fn(), 0);
+
 /**
  * Calls the specified callback with the result of the promise.
  *
@@ -10,7 +12,8 @@
  * @param {Function<Err, Any>} cb - An errback.
  */
 function asCallback(promise, cb) {
-  promise.then((res) => cb(null, res), cb);
+  const callback = (...args) => tick(() => cb(...args));
+  promise.then((res) => callback(null, res), callback);
 }
 
 module.exports = asCallback;


### PR DESCRIPTION
Previously, exceptions thrown by the callback provided to `asCallback` would get swallowed in the inaccessible `Promise` constructed by the `then` invocation. At best, this would cause these exceptions to crash the Node process with an unhandled rejection, and at worst these would get silently consumed and emptied into the void.

This is both (I'm pretty sure) a non-breaking change, and a change that may break things.

To wit: this is part of the intended API contract, and is not changing that API contract, even though it may reveal downstream problems by being better at error reporting.