### PR TITLE
perf: avoid deoptimized arguments passing

### DIFF
--- a/src/callbackBuilder.js
+++ b/src/callbackBuilder.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { slice } = require('./utils');
-
 /**
  * Build a callback for the given promise resolve/reject functions.
  *
@@ -30,8 +28,14 @@ function callbackBuilder(resolve, reject, options) {
         obj[variadic[i]] = arguments[i + 1];
       }
       resolve(obj);
+    } else if (variadic) {
+      const args = new Array(arguments.length - 1);
+      for (let i = 0; i < args.length; ++i) {
+        args[i] = arguments[i + 1];
+      }
+      resolve(args);
     } else {
-      resolve(variadic ? slice(arguments, 1) : value);
+      resolve(value);
     }
   };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const arraySlice = Array.prototype.slice;
-
 const fromEntries =
   Object.fromEntries ||
   function fromEntries(entries) {
@@ -12,11 +10,6 @@ const fromEntries =
     return obj;
   };
 
-function slice(arrayLike, offset) {
-  return arraySlice.call(arrayLike, offset);
-}
-
 module.exports = {
   fromEntries,
-  slice,
 };


### PR DESCRIPTION
It's well established that passing around the arguments value [results in code deoptimization][1]. We should avoid doing so, and prefer explicitly converting arguments to an array.

[1]: https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#3-managing-arguments